### PR TITLE
Implement support for .patch.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@rjsf/validator-ajv8": "^5.24.13",
         "antd": "^5.25.2",
         "electron-debug": "^4.0.0",
+        "fast-json-patch": "^3.1.1",
+        "proxy-memoize": "^3.0.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
@@ -12475,6 +12477,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -18366,6 +18374,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-memoize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
+      "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.0"
       }
     },
     "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@rjsf/validator-ajv8": "^5.24.13",
     "antd": "^5.25.2",
     "electron-debug": "^4.0.0",
+    "fast-json-patch": "^3.1.1",
+    "proxy-memoize": "^3.0.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",

--- a/src-rust/src/invokables/json.rs
+++ b/src-rust/src/invokables/json.rs
@@ -1,75 +1,168 @@
 use std::fs::{read_to_string, write};
-use std::{path::Path, str::FromStr};
+use std::io::{self, ErrorKind};
+use std::path::Path;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use stracciatella::{unicode::Nfc, vfs::VfsLayer};
+use stracciatella::unicode::Nfc;
 
 use crate::{
     error::{Error, Result},
     state,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OpenFileOptions {
-    file: String,
-}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Filename(String);
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct JsonFileWithSchema {
-    content: Value,
-    schema: Value,
-}
-
-pub fn open_json_file_with_schema(
-    state: &state::AppState,
-    file: OpenFileOptions,
-) -> Result<JsonFileWithSchema> {
-    if file.file.contains("..") {
-        return Err(Error::new("file path cannot contain `..`"));
+impl Filename {
+    fn validate(&self) -> Result<()> {
+        if self.0.contains("..") {
+            return Err(Error::new("file path cannot contain `..`"));
+        }
+        if !self.0.ends_with(".json") {
+            return Err(Error::new("file path must end with `.json`"));
+        }
+        Ok(())
     }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+
+    fn patch_filename(&self) -> Self {
+        let mut f = self.0.strip_suffix(".json").unwrap().to_owned();
+        f.push_str(".patch.json");
+        Self(f)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Persisted {
+    value: Option<Value>,
+    patch: Option<Vec<Value>>,
+}
+
+impl AsRef<str> for Filename {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenFileParams {
+    filename: Filename,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonFileWithSchema {
+    schema: Value,
+    vanilla: Value,
+    #[serde(flatten)]
+    persisted: Persisted,
+}
+
+pub fn open_json_with_schema(
+    state: &state::AppState,
+    params: OpenFileParams,
+) -> Result<JsonFileWithSchema> {
+    let filename = &params.filename;
+    filename.validate()?;
 
     let state = state.read();
     let schema_manager = state.try_schema_manager()?;
     let selected_mod = state.try_selected_mod()?;
     let schema = schema_manager
-        .get(Path::new(&file.file))
-        .ok_or_else(|| Error::new(format!("schema for `{}` not found", file.file)))?;
+        .get(&Path::new(filename.as_str()))
+        .ok_or_else(|| Error::new(format!("schema for `{}` not found", filename.as_str())))?;
     let schema = Value::from_str(schema.as_str())?;
-    let path = selected_mod.data_path(&file.file);
+    let path = selected_mod.data_path(filename.as_str());
+    let patch_path = selected_mod.data_path(filename.patch_filename().as_str());
 
-    let content: Value = if path.exists() {
+    let vanilla = selected_mod
+        .vfs
+        .read_patched_json(&Nfc::caseless(filename.as_str()))?;
+    let value: Option<Value> = if path.exists() {
         let json = read_to_string(&path)?;
-        stracciatella::json::de::from_string(&json)
-            .map_err(|e| Error::new(format!("error decoding data for `{:?}`: {}", file, e)))?
+        stracciatella::json::de::from_string(&json).map_err(|e| {
+            Error::new(format!(
+                "error decoding patch data for `{:?}`: {}",
+                filename, e
+            ))
+        })?
     } else {
-        let mut f = selected_mod.vfs.open(&Nfc::caseless(&file.file))?;
-        let mut json = String::new();
-        f.read_to_string(&mut json)?;
-        stracciatella::json::de::from_string(&json)
-            .map_err(|e| Error::new(format!("error decoding data for `{:?}`: {}", file, e)))?
+        None
+    };
+    let patch: Option<Vec<Value>> = if patch_path.exists() {
+        let json = read_to_string(&patch_path)?;
+        stracciatella::json::de::from_string(&json).map_err(|e| {
+            Error::new(format!(
+                "error decoding patch data for `{:?}`: {}",
+                filename, e
+            ))
+        })?
+    } else {
+        None
     };
 
-    Ok(JsonFileWithSchema { content, schema })
+    Ok(JsonFileWithSchema {
+        schema,
+        vanilla,
+        persisted: Persisted { value, patch },
+    })
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PersistFileOptions {
-    file: String,
-    content: Value,
+pub struct PersistFileParams {
+    filename: Filename,
+    #[serde(flatten)]
+    values: Persisted,
 }
 
-pub fn persist_json_file(state: &state::AppState, file: PersistFileOptions) -> Result<()> {
-    if file.file.contains("..") {
-        return Err(Error::new("file path cannot contain `..`"));
-    }
+pub fn persist_json(state: &state::AppState, params: PersistFileParams) -> Result<Persisted> {
+    let filename = &params.filename;
+    filename.validate()?;
 
     let state = state.read();
     let selected_mod = state.try_selected_mod()?;
-    let path = selected_mod.data_path(&file.file);
-    let content = serde_json::to_string(&file.content)?;
 
-    write(&path, &content)?;
+    let path = selected_mod.data_path(filename.as_str());
+    if let Some(mod_value) = &params.values.value {
+        let content = serde_json::to_string_pretty(&mod_value)?;
+        write(&path, &content)?;
+    } else {
+        delete_file(&path)?;
+    }
 
-    Ok(())
+    let mut rewrite_patch_to_none = false;
+    let path = selected_mod.data_path(filename.patch_filename().as_str());
+    if let Some(mod_patch_value) = &params.values.patch {
+        if !mod_patch_value.is_empty() {
+            let content = serde_json::to_string_pretty(&mod_patch_value)?;
+            write(&path, &content)?;
+        } else {
+            rewrite_patch_to_none = true;
+            delete_file(&path)?;
+        }
+    } else {
+        delete_file(&path)?;
+    }
+
+    Ok(Persisted {
+        value: params.values.value.clone(),
+        patch: if rewrite_patch_to_none {
+            None
+        } else {
+            params.values.patch.clone()
+        },
+    })
+}
+
+fn delete_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    if let Err(e) = std::fs::remove_file(path.as_ref()) {
+        if e.kind() != ErrorKind::NotFound {
+            return Err(e.into());
+        }
+    }
+    return Ok(());
 }

--- a/src-rust/src/lib.rs
+++ b/src-rust/src/lib.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use invokables::{
     images::ReadImageFileParams,
-    json::{OpenFileOptions, PersistFileOptions},
+    json::{OpenFileParams, PersistFileParams},
     mods::SelectedMod,
     resources::ListResourcesParams,
     sounds::ReadSoundParams,
@@ -90,15 +90,15 @@ fn invoke_inner(state: &state::AppState, payload: &str) -> Result<String> {
                 let s = invokables::mods::create_new_mod(&state, new_mod)?;
                 Ok(serde_json::to_value(s)?)
             }
-            "open_json_file_with_schema" => {
-                let file: OpenFileOptions = serde_json::from_value(payload.params.clone())?;
-                let json = invokables::json::open_json_file_with_schema(&state, file)?;
+            "open_json_with_schema" => {
+                let file: OpenFileParams = serde_json::from_value(payload.params.clone())?;
+                let json = invokables::json::open_json_with_schema(&state, file)?;
                 Ok(serde_json::to_value(json)?)
             }
-            "persist_json_file" => {
-                let file: PersistFileOptions = serde_json::from_value(payload.params.clone())?;
-                invokables::json::persist_json_file(&state, file)?;
-                Ok(serde_json::to_value("success")?)
+            "persist_json" => {
+                let file: PersistFileParams = serde_json::from_value(payload.params.clone())?;
+                let json = invokables::json::persist_json(&state, file)?;
+                Ok(serde_json::to_value(json)?)
             }
             "read_image_file" => {
                 let params: ReadImageFileParams = serde_json::from_value(payload.params.clone())?;

--- a/src/renderer/components/EditorContent.tsx
+++ b/src/renderer/components/EditorContent.tsx
@@ -1,36 +1,93 @@
 import { ExclamationCircleOutlined, SaveOutlined } from '@ant-design/icons';
-import { Button, Space } from 'antd';
+import { Button, Flex, Select, Space, Typography } from 'antd';
 import { ReactNode, memo, useCallback, useMemo } from 'react';
 import './EditorContent.css';
 import { useAppDispatch, useAppSelector } from '../hooks/state';
-import { saveJSON } from '../state/files';
+import { changeSaveMode, persistJSON, SaveMode } from '../state/files';
+import {
+  useFileError,
+  useFileModified,
+  useFileSaveMode,
+  useFileSaving,
+} from '../hooks/files';
+
+const SAVE_MODE_SELECT_OPTIONS = [
+  {
+    label: 'Patch',
+    title:
+      'Use this option if your mod should only adapt content, not fully replace it. The resulting file will only contain the changes you made to the original file.',
+    value: 'patch',
+  },
+  {
+    label: 'Replace',
+    title:
+      'Use this option if you want to fully replace content from vanilla or other mods. The resulting file will contain the modified original file.',
+    value: 'replace',
+  },
+];
 
 interface ContentProps {
   path: string;
   children: ReactNode;
 }
 
-const EditorContentHeader = memo(({ path }: { path: string }) => {
+const EditorContentHeader = memo(function EditorContentHeader({
+  path,
+}: {
+  path: string;
+}) {
   const dispatch = useAppDispatch();
-  const modified = useAppSelector((s) => s.files.json[path]?.content?.modified);
-  const error = useAppSelector((s) => s.files.json[path]?.error);
+  const modified = useFileModified(path);
+  const saving = useFileSaving(path);
+  const saveMode = useFileSaveMode(path);
+  const error = useFileError(path);
   const errorStyle = useMemo(() => ({ color: '#9d1e1c' }), []);
   const saveFileToPath = useCallback(() => {
-    dispatch(saveJSON(path));
+    dispatch(
+      persistJSON({
+        filename: path,
+      }),
+    );
   }, [dispatch, path]);
+  const setSaveMode = useCallback(
+    (saveMode: SaveMode) => {
+      dispatch(
+        changeSaveMode({
+          filename: path,
+          saveMode,
+        }),
+      );
+    },
+    [dispatch, path],
+  );
+
   return (
-    <Space>
-      <Button disabled={!modified}>
-        <SaveOutlined onClick={saveFileToPath} />
-      </Button>
-      {error ? (
-        <ExclamationCircleOutlined title={error.message} style={errorStyle} />
-      ) : null}
-    </Space>
+    <Flex justify="space-between">
+      <Space>
+        <Button disabled={!modified || !!saving}>
+          <SaveOutlined onClick={saveFileToPath} />
+        </Button>
+        {error ? (
+          <ExclamationCircleOutlined title={error.message} style={errorStyle} />
+        ) : null}
+      </Space>
+      <Space>
+        <Typography>Save Mode</Typography>
+        <Select
+          style={{ minWidth: '150px' }}
+          options={SAVE_MODE_SELECT_OPTIONS}
+          value={saveMode}
+          onChange={setSaveMode}
+        />
+      </Space>
+    </Flex>
   );
 });
 
-export function EditorContent({ path, children }: ContentProps) {
+export const EditorContent = memo(function EditorContent({
+  path,
+  children,
+}: ContentProps) {
   return (
     <div className="editor-content">
       <div className="editor-content-header">
@@ -39,4 +96,4 @@ export function EditorContent({ path, children }: ContentProps) {
       <div className="editor-content-content">{children}</div>
     </div>
   );
-}
+});

--- a/src/renderer/components/ErrorAlert.tsx
+++ b/src/renderer/components/ErrorAlert.tsx
@@ -2,14 +2,14 @@ import { SerializedError } from '@reduxjs/toolkit';
 import { Alert, Typography } from 'antd';
 
 interface ErrorAlertProps {
-  error: SerializedError | null;
+  error: { message?: string } | null;
 }
 
 export function ErrorAlert({ error }: ErrorAlertProps) {
   if (!error) return null;
   return (
     <Typography.Paragraph>
-      <Alert type="error" message={error.message} />
+      <Alert type="error" message={error.message ?? ''} />
     </Typography.Paragraph>
   );
 }

--- a/src/renderer/components/JsonSchemaForm.tsx
+++ b/src/renderer/components/JsonSchemaForm.tsx
@@ -5,14 +5,17 @@ import { UiSchema, FieldTemplateProps, FieldProps } from '@rjsf/utils';
 import { Theme as AntdTheme } from '@rjsf/antd';
 import { Form } from 'antd';
 import ReactMarkdown from 'react-markdown';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import validator from '@rjsf/validator-ajv8';
 
 export interface DescriptionFieldProps extends Partial<FieldProps> {
   description?: string;
 }
 
-function MarkdownDescriptionField({ id, description }: DescriptionFieldProps) {
+const MarkdownDescriptionField = memo(function MarkdownDescriptionField({
+  id,
+  description,
+}: DescriptionFieldProps) {
   if (!description) {
     return null;
   }
@@ -21,13 +24,13 @@ function MarkdownDescriptionField({ id, description }: DescriptionFieldProps) {
       <ReactMarkdown>{description}</ReactMarkdown>
     </div>
   );
-}
+});
 
 const HORIZONTAL_LABEL_COL = { span: 6 };
 const HORIZONTAL_WRAPPER_COL = { span: 18 };
 
 // Cloned from Antd theme with some changes
-function MarkdownFieldTemplate({
+const MarkdownFieldTemplate = memo(function MarkdownFieldTemplate({
   children,
   classNames,
   description,
@@ -94,7 +97,7 @@ FieldTemplateProps) {
       {children}
     </Form.Item>
   );
-}
+});
 
 const RjsfForm = withTheme({
   ...AntdTheme,

--- a/src/renderer/components/content/MercPreview.tsx
+++ b/src/renderer/components/content/MercPreview.tsx
@@ -2,7 +2,7 @@ import { QuestionOutlined } from '@ant-design/icons';
 import { Avatar } from 'antd';
 import { useMemo } from 'react';
 import { useImageFile } from '../../hooks/useImage';
-import { useJson } from '../../hooks/files';
+import { useFileJson } from '../../hooks/files';
 
 interface MercPreviewProps {
   profile: string;
@@ -11,13 +11,16 @@ interface MercPreviewProps {
 const crispEdgesStyle = { imageRendering: 'crisp-edges' as const };
 
 export function MercPreview({ profile }: MercPreviewProps) {
-  const { content } = useJson('mercs-profile-info.json');
+  const [content] = useFileJson('mercs-profile-info.json');
   const profileId = useMemo(() => {
     if (!content) {
       return null;
     }
-    const p = content.value.find((it: any) => it.internalName === profile);
-    if (!p) {
+    if (!Array.isArray(content)) {
+      return null;
+    }
+    const p = content.find((it: any) => it.internalName === profile);
+    if (!p || !p.profileID) {
       return null;
     }
     return p.profileID as number;

--- a/src/renderer/components/form/JsonFormHeader.tsx
+++ b/src/renderer/components/form/JsonFormHeader.tsx
@@ -1,14 +1,16 @@
 import { memo, useMemo } from 'react';
-import { useAppSelector } from '../../hooks/state';
 import { Typography } from 'antd';
 import ReactMarkdown from 'react-markdown';
+import { useFileSchema } from '../../hooks/files';
 
 interface JsonFormHeaderProps {
   file: string;
 }
 
-function Header({ file }: JsonFormHeaderProps) {
-  const schema = useAppSelector((s) => s.files.json[file]?.content?.schema);
+export const JsonFormHeader = memo(function Header({
+  file,
+}: JsonFormHeaderProps) {
+  const schema = useFileSchema(file);
   const title = useMemo(() => schema?.title, [schema]) ?? file;
   const description = useMemo(() => schema?.description, [schema]) ?? null;
   const itemsDescription =
@@ -27,6 +29,4 @@ function Header({ file }: JsonFormHeaderProps) {
       </div>
     </div>
   );
-}
-
-export const JsonFormHeader = memo(Header);
+});

--- a/src/renderer/state/files.tsx
+++ b/src/renderer/state/files.tsx
@@ -5,72 +5,138 @@ import {
 } from '@reduxjs/toolkit';
 import type { PayloadAction, SerializedError } from '@reduxjs/toolkit';
 import { z } from 'zod';
+import { applyReducer, Operation, compare } from 'fast-json-patch';
 import { invokeWithSchema } from '../lib/invoke';
+import { deepEquals } from '@rjsf/utils';
+
+const anyJsonObjectSchema = z.object().catchall(z.any());
+const jsonRootSchema = z.union([
+  anyJsonObjectSchema,
+  z.array(anyJsonObjectSchema),
+  z.array(z.array(z.any())),
+]);
+export type JsonRoot = z.infer<typeof jsonRootSchema>;
+const jsonPatchSchema = z.array(
+  z.object({ op: z.any(), path: z.any(), value: z.optional(z.any()) }),
+);
+export type JsonPatch = Array<Operation>;
+const jsonSchemaSchema = z
+  .object({
+    title: z.optional(z.string()),
+    description: z.optional(z.string()),
+    items: z.optional(anyJsonObjectSchema),
+  })
+  .catchall(z.any());
+export type JsonSchema = z.infer<typeof jsonSchemaSchema>;
+
+export type SaveMode = 'patch' | 'replace';
 
 interface JsonFile {
-  loading: boolean;
+  loading: boolean | null;
+  saving: boolean | null;
   error: SerializedError | null;
   content: {
-    modified: boolean;
-    schema: any;
-    value: any;
+    schema: JsonSchema;
+    vanilla: JsonRoot;
+    mod: JsonRoot | null;
+    patch: JsonPatch | null;
+    applied: JsonRoot | null;
+    saveMode: SaveMode;
   } | null;
 }
 
 interface FilesState {
-  json: {
-    [path: string]: JsonFile | undefined;
-  };
+  disk: Record<string, JsonFile>;
+  open: Record<string, JsonRoot>;
+  saveMode: Record<string, SaveMode>;
+  modified: Record<string, boolean>;
 }
 
 const initialState: FilesState = {
-  json: {},
+  disk: {},
+  saveMode: {},
+  open: {},
+  modified: {},
 };
 
 export const loadJSON = createAsyncThunk(
   'files/load-json',
-  async (file: string) => {
+  async (filename: string) => {
     return invokeWithSchema(
       z.object({
-        content: z.any(),
-        schema: z.any(),
+        schema: jsonSchemaSchema,
+        vanilla: jsonRootSchema,
+        value: z.union([jsonRootSchema, z.null()]),
+        patch: z.union([jsonPatchSchema, z.null()]),
       }),
-      'open_json_file_with_schema',
+      'open_json_with_schema',
       {
-        file,
+        filename,
       },
     );
   },
 );
 
-export const saveJSON = createAsyncThunk(
-  'files/save-json',
-  async (file: string, { getState }) => {
+export const persistJSON = createAsyncThunk(
+  'files/persist-json',
+  async ({ filename }: { filename: string }, { getState }) => {
     const { files } = getState() as { files: FilesState };
-    const content = files.json[file]?.content?.value;
 
-    if (!content) {
-      throw new Error('no content for file to save');
+    const editorValue = files.open[filename] ?? null;
+    const mode = files.saveMode[filename] ?? null;
+    if (editorValue === null || mode === null) {
+      throw new Error('tried to save a non-open file');
     }
 
-    return invokeWithSchema(z.any(), 'persist_json_file', {
-      file,
-      content,
-    });
+    const vanillaValue = files.disk[filename]?.content?.vanilla ?? null;
+    if (vanillaValue === null) {
+      throw new Error('tried to save a non-loaded file');
+    }
+
+    const toSynchronize: {
+      filename: string;
+      value: JsonRoot | null;
+      patch: JsonPatch | null;
+    } = {
+      filename,
+      value: editorValue,
+      patch: null,
+    };
+    if (mode == 'patch') {
+      toSynchronize.value = null;
+      toSynchronize.patch = compare(vanillaValue, editorValue);
+    }
+
+    return invokeWithSchema(
+      z.object({
+        value: z.union([jsonRootSchema, z.null()]),
+        patch: z.union([jsonPatchSchema, z.null()]),
+      }),
+      'persist_json',
+      toSynchronize,
+    );
   },
 );
 
-function getJsonState(state: FilesState, file: string): JsonFile {
-  let f = state.json[file];
-  if (!f) {
-    f = {
-      loading: true,
+function getDiskState(state: FilesState, filename: string): JsonFile {
+  if (!state.disk[filename]) {
+    state.disk[filename] = {
+      saving: null,
+      loading: null,
       error: null,
       content: null,
     };
-    state.json[file] = f;
   }
-  return f;
+  return state.disk[filename];
+}
+
+function isModified(files: FilesState, filename: string) {
+  const diskSaveMode = files.disk[filename]?.content?.saveMode ?? null;
+  const diskValue = files.disk[filename]?.content?.applied ?? null;
+  const value = files.open[filename] ?? null;
+  const saveMode = files.saveMode[filename] ?? null;
+
+  return diskSaveMode != saveMode || !deepEquals(diskValue, value);
 }
 
 const filesSlice = createSlice({
@@ -79,92 +145,132 @@ const filesSlice = createSlice({
   reducers: {
     changeJson: (
       state,
-      action: PayloadAction<{ file: string; value: any }>,
+      action: PayloadAction<{ filename: string; value: JsonRoot }>,
     ) => {
-      const c = getJsonState(state, action.payload.file);
-      c.loading = false;
-      if (c.content) {
-        c.error = null;
-        c.content.modified = true;
-        c.content.value = action.payload.value;
-      } else {
-        c.error = miniSerializeError(
-          new Error('changed json content of unloaded file'),
-        );
-      }
+      const { filename, value } = action.payload;
+      const f = getDiskState(state, filename);
+
+      state.open[filename] = value;
+      state.modified[filename] = isModified(state, filename);
     },
     changeJsonItem: (
       state,
-      action: PayloadAction<{ file: string; index: number; value: any }>,
+      action: PayloadAction<{ filename: string; index: number; value: any }>,
     ) => {
-      const c = getJsonState(state, action.payload.file);
-      c.loading = false;
-      if (c.content) {
-        if (c.content.value.length) {
-          c.error = null;
-          c.content.modified = true;
-          c.content.value[action.payload.index] = action.payload.value;
-        } else {
-          c.error = miniSerializeError(
-            new Error('changed json item of non array file'),
-          );
-        }
-      } else {
-        c.error = miniSerializeError(
-          new Error('changed json item of unloaded file'),
+      const { filename, index, value } = action.payload;
+      const f = getDiskState(state, filename);
+      const o = state.open[filename];
+      if (!Array.isArray(o)) {
+        f.error = miniSerializeError(
+          new Error('tried to change item of a non-array file'),
         );
+        return;
       }
+      (o as Array<any>)[index] = value;
+      state.modified[filename] = isModified(state, filename);
+    },
+    changeSaveMode(
+      state,
+      action: PayloadAction<{ filename: string; saveMode: SaveMode }>,
+    ) {
+      const { filename, saveMode } = action.payload;
+      const f = getDiskState(state, filename);
+      const o = state.open[filename];
+      state.saveMode[filename] = saveMode;
+      state.modified[filename] = isModified(state, filename);
     },
   },
   extraReducers: (builder) => {
     builder.addCase(loadJSON.pending, (state, action) => {
       const file = action.meta.arg;
-      const c = getJsonState(state, file);
+      const c = getDiskState(state, file);
       c.loading = true;
       c.error = null;
     });
     // TODO: Find a way to extract (same as setSelectedMod)
     builder.addCase(loadJSON.rejected, (state, action) => {
       const file = action.meta.arg;
-      const c = getJsonState(state, file);
+      const c = getDiskState(state, file);
       c.loading = false;
       c.error = action.error;
     });
     // TODO: Find a way to extract (same as setSelectedMod)
     builder.addCase(loadJSON.fulfilled, (state, action) => {
       const file = action.meta.arg;
-      const c = getJsonState(state, file);
+      const c = getDiskState(state, file);
+      const saveMode = action.payload.value ? 'replace' : 'patch';
+      const applied = (action.payload.patch ?? []).reduce(
+        applyReducer,
+        JSON.parse(
+          JSON.stringify(action.payload.value ?? action.payload.vanilla),
+        ),
+      );
+
       c.loading = false;
       c.error = null;
       c.content = {
-        modified: false,
         schema: action.payload.schema,
-        value: action.payload.content,
+        vanilla: action.payload.vanilla,
+        mod: action.payload.value,
+        patch: action.payload.patch as Array<Operation> | null,
+        applied,
+        saveMode,
       };
+
+      if (!state.saveMode[file]) {
+        state.saveMode[file] = action.payload.value ? 'replace' : 'patch';
+      }
+      if (!state.open[file]) {
+        state.open[file] = applied;
+      }
     });
 
-    builder.addCase(saveJSON.pending, (state, action) => {
-      const file = action.meta.arg;
-      const c = getJsonState(state, file);
+    builder.addCase(persistJSON.pending, (state, action) => {
+      const { filename } = action.meta.arg;
+      const c = getDiskState(state, filename);
+      c.saving = true;
       c.error = null;
     });
-    builder.addCase(saveJSON.rejected, (state, action) => {
-      const file = action.meta.arg;
-      const c = getJsonState(state, file);
+    builder.addCase(persistJSON.rejected, (state, action) => {
+      const { filename } = action.meta.arg;
+      const c = getDiskState(state, filename);
+      c.saving = false;
       c.error = action.error;
     });
-    builder.addCase(saveJSON.fulfilled, (state, action) => {
-      const file = action.meta.arg;
-      const c = getJsonState(state, file);
+    builder.addCase(persistJSON.fulfilled, (state, action) => {
+      const { filename } = action.meta.arg;
+
+      const c = getDiskState(state, filename);
+      c.saving = false;
+
       const { content } = c;
-      if (content) {
-        content.modified = false;
+      if (content === null) {
+        c.error = miniSerializeError(new Error('saved non-loaded file'));
+        return;
       }
+
+      const o = state.open[filename];
+      if (o === null) {
+        c.error = miniSerializeError(new Error('saved non-open file'));
+        return;
+      }
+
+      content.mod = action.payload.value;
+      content.patch = action.payload.patch;
+      content.saveMode = state.saveMode[filename];
+
+      const applied = (content.patch ?? []).reduce(
+        applyReducer,
+        JSON.parse(JSON.stringify(content.mod ?? content.vanilla)),
+      );
+      content.applied = applied;
+
+      state.modified[filename] = isModified(state, filename);
     });
   },
 });
 
 export const files = filesSlice.reducer;
 
-export const { changeJson } = filesSlice.actions;
-export const { changeJsonItem } = filesSlice.actions;
+export const { changeJson, changeJsonItem, changeSaveMode } =
+  filesSlice.actions;


### PR DESCRIPTION
Now there is a `saveMode` that you can switch between saving a patch and saving the whole file. It defaults to saving a patch for files that were not modified yet. You can also switch between the modes, which will automatically generate a patch from the full file and vice versa.

Closes #5 

<img width="3820" height="1111" alt="image" src="https://github.com/user-attachments/assets/5560d495-ac17-41f5-8016-c05a0267b882" />
